### PR TITLE
webapp-runner: 9.0.68.1 -> 9.0.93.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.12.18" // https://scalameta.org/metals/blog/2023/07/19/silver
 // webapp-runner
 lazy val webappRunnerVersion =
   settingKey[String]("webapp-runner version")
-webappRunnerVersion := "9.0.68.1"
+webappRunnerVersion := "9.0.93.0"
 libraryDependencies += "com.heroku" % "webapp-runner" % webappRunnerVersion.value intransitive ()
 
 // Java-only


### PR DESCRIPTION
📦 Updates [com.heroku:webapp-runner](https://github.com/heroku/webapp-runner) from `9.0.68.1` to `9.0.93.0`

📜 [GitHub Release Notes](https://github.com/heroku/webapp-runner/releases/tag/v9.0.93.0) - [Version Diff](https://github.com/heroku/webapp-runner/compare/v9.0.68.1...v9.0.93.0)