### PR TITLE
scala-library: 2.12.18 -> 2.12.20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.earldouglas"
 
 // Build
 scalacOptions ++= Seq("-feature", "-deprecation")
-scalaVersion := "2.12.18" // https://scalameta.org/metals/blog/2023/07/19/silver#support-for-scala-21218
+scalaVersion := "2.12.20" // https://scalameta.org/metals/blog/2023/07/19/silver#support-for-scala-21218
 
 // webapp-runner
 lazy val webappRunnerVersion =


### PR DESCRIPTION
📦 Updates [org.scala-lang:scala-library](https://github.com/scala/scala) from `2.12.18` to `2.12.20`

📜 [GitHub Release Notes](https://github.com/scala/scala/releases/tag/v2.12.20) - [Version Diff](https://github.com/scala/scala/compare/v2.12.18...v2.12.20)